### PR TITLE
Add full Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A convenient converter of [DConf](https://wiki.gnome.org/Projects/dconf) files t
 * [Introduction](#introduction)
 * [Run](#run)
   * [Custom root](#custom-root)
-  * [Emoji support](#emoji-support)
 * [Supported types](#supported-types)
 * [Gnome Shell configuration](#gnome-shell-configuration)
 * [Installation](#installation)
@@ -107,20 +106,18 @@ Type `--help` for some more information.
 dconf2nix - Nixify dconf configuration files
 
 Usage: dconf2nix [-v|--version] 
-                 [[-r|--root ARG] [-e|--emoji] [--verbose] | (-i|--input ARG)
-                   (-o|--output ARG) [-r|--root ARG] [-e|--emoji] [--verbose]]
+                 [[-r|--root ARG] [--verbose] | (-i|--input ARG)
+                   (-o|--output ARG) [-r|--root ARG] [--verbose]]
   Convert a dconf file into a Nix file, as expected by Home Manager.
 
 Available options:
   -h,--help                Show this help text
   -v,--version             Show the current version
   -r,--root ARG            Custom root path. e.g.: system/locale/
-  -e,--emoji               Enable emoji support (adds a bit of overhead)
   --verbose                Verbose mode (debug)
   -i,--input ARG           Path to the dconf file (input)
   -o,--output ARG          Path to the Nix output file (to be created)
   -r,--root ARG            Custom root path. e.g.: system/locale/
-  -e,--emoji               Enable emoji support (adds a bit of overhead)
   --verbose                Verbose mode (debug)
 ```
 
@@ -144,26 +141,6 @@ This will generate an output similar to the one below.
   };
 }
 ```
-
-#### Emoji support
-
-Emojis are supported since version `0.0.12`, and it needs to be explicitly enabled, as these add a little parsing overhead via the [emojis](https://hackage.haskell.org/package/emojis) package.
-
-The following `dconf` input.
-
-```ini
-[ org/gnome/Characters ]
-recent-characters=['💡']
-some-other-character=['🤓']
-```
-
-Can be parsed as follows.
-
-```console 
-$ dconf2nix -i data/emoji.settings -o output/emoji.nix --emoji
-```
-
-Failing to pass the `--emoji` flag will result in a timeout error.
 
 ### Supported types
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import           DConf2Nix                      ( dconf2nixFile
 
 main :: IO ()
 main = runArgs >>= \case
-  FileInput (FileArgs i o r e v) ->
-    dconf2nixFile i o r e v
-  StdinInput (StdinArgs r e v)   ->
-    dconf2nixStdin r e v
+  FileInput (FileArgs i o r v) ->
+    dconf2nixFile i o r v
+  StdinInput (StdinArgs r v)   ->
+    dconf2nixStdin r v

--- a/data/dconf.settings
+++ b/data/dconf.settings
@@ -303,7 +303,7 @@ locations=[<(uint32 2, <('Gdańsk', 'EPGD', true, [(0.94916821905848536, 0.32230
 region='en_US.UTF-8'
 
 [issue28/desktop/ibus/panel/emoji]
-favorites=['\8211', '\8594', '\8593', '\8595', '\8482', '\\u00ad', '\176', '\\v', '\160', '\171', '\8451']
+favorites=['–', '→', '↑', '↓', '™', '\u00ad', '°', '\v', ' ', '«', '℃']
 
 [issue28/org/gnome/desktop/input-sources]
 mru-sources=[('xkb', 'us+altgr-intl'), ('ibus', 'mozc-jp')]

--- a/data/unicode.settings
+++ b/data/unicode.settings
@@ -1,0 +1,3 @@
+[org/gnome/font-manager]
+compare-preview-text='🤣'
+preview-text='příliš žluťoučký kůň úpěl ďábelské ódy\nprilis zlutoucky kun upel dabelske ody\n◌̍◌̍ff̍ ̍čěů\n◌̎\n'

--- a/dconf2nix.cabal
+++ b/dconf2nix.cabal
@@ -21,7 +21,6 @@ library
   other-modules:       Paths_dconf2nix
   build-depends:       base
                      , containers
-                     , emojis
                      , optparse-applicative
                      , parsec
                      , text

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -361,12 +361,12 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/Weather" = {
-      locations = [ (mkVariant [ (mkUint32 2) (mkVariant [ "Gda\324sk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Dzia\322dowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) ];
+      locations = [ (mkVariant [ (mkUint32 2) (mkVariant [ "Gdańsk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) ];
     };
 
     "org/gnome/shell/weather" = {
       automatic-location = true;
-      locations = [ (mkVariant [ (mkUint32 2) (mkVariant [ "Gda\324sk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Dzia\322dowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) ];
+      locations = [ (mkVariant [ (mkUint32 2) (mkVariant [ "Gdańsk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ]) ]) (mkVariant [ (mkUint32 2) (mkVariant [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ]) ]) ];
     };
 
     "system/locale" = {
@@ -374,7 +374,7 @@ with lib.hm.gvariant;
     };
 
     "issue28/desktop/ibus/panel/emoji" = {
-      favorites = [ "\137" "\396" "\395" "\397" "\322" "\\u00ad" "\176" "\\v" "\160" "\171" "\297" ];
+      favorites = [ "–" "→" "↑" "↓" "™" "­" "°" "" " " "«" "℃" ];
     };
 
     "issue28/org/gnome/desktop/input-sources" = {

--- a/output/unicode.nix
+++ b/output/unicode.nix
@@ -1,0 +1,14 @@
+# Generated via dconf2nix: https://github.com/nix-commmunity/dconf2nix
+{ lib, ... }:
+
+with lib.hm.gvariant;
+
+{
+  dconf.settings = {
+    "org/gnome/font-manager" = {
+      compare-preview-text = "🤣";
+      preview-text = "příliš žluťoučký kůň úpěl ďábelské ódy\nprilis zlutoucky kun upel dabelske ody\n◌̍◌̍ff̍ ̍čěů\n◌̎\n";
+    };
+
+  };
+}

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -18,23 +18,17 @@ data FileArgs = FileArgs
   { fileInput :: InputFilePath
   , fileOutput :: OutputFilePath
   , fileRoot :: Root
-  , fileEmojiSupport :: EmojiSupport
   , fileVerbosity :: Verbosity
   }
 
 data StdinArgs = StdinArgs
   { stdinRoot :: Root
-  , stdinEmojiSupport :: EmojiSupport
   , stdinVerbosity :: Verbosity
   }
 
 verbosityArgs :: Parser Verbosity
 verbosityArgs =
   flag Normal Verbose (long "verbose" <> help "Verbose mode (debug)")
-
-emojiArgs :: Parser EmojiSupport
-emojiArgs =
-  flag Disabled Enabled (long "emoji" <> short 'e' <> help "Enable emoji support (adds a bit of overhead)")
 
 rootArgs :: Parser Root
 rootArgs = Root <$> strOption
@@ -53,12 +47,11 @@ fileArgs = fmap FileInput $ FileArgs
           )
         )
     <*> rootArgs
-    <*> emojiArgs
     <*> verbosityArgs
 
 stdinArgs :: Parser Input
 stdinArgs =
-  StdinInput <$> (StdinArgs <$> rootArgs <*> emojiArgs <*> verbosityArgs)
+  StdinInput <$> (StdinArgs <$> rootArgs <*> verbosityArgs)
 
 versionInfo :: String
 versionInfo = unlines

--- a/src/DConf/Data.hs
+++ b/src/DConf/Data.hs
@@ -6,7 +6,6 @@ import           Data.Text                      ( Text )
 newtype InputFilePath = InputFilePath FilePath deriving Show
 newtype OutputFilePath = OutputFilePath FilePath deriving Show
 
-data EmojiSupport = Enabled | Disabled
 data Verbosity = Normal | Verbose
 
 newtype Nix = Nix { unNix :: Text } deriving Show
@@ -21,7 +20,6 @@ data Value = S Text         -- String
            | I32 Int        -- Int32
            | I64 Int        -- Int64
            | D Double       -- Double
-           | Emo Char       -- Emoji (Unicode char)
            | T [Value]      -- Tuple of n-arity
            | L [Value]      -- List of values
            | V [Value]      -- Variant

--- a/src/DConf2Nix.hs
+++ b/src/DConf2Nix.hs
@@ -13,16 +13,16 @@ import           Text.Parsec                    ( ParseError
                                                 , runParser
                                                 )
 
-dconf2nixFile :: InputFilePath -> OutputFilePath -> Root -> EmojiSupport -> Verbosity -> IO ()
-dconf2nixFile (InputFilePath input) (OutputFilePath output) root es v =
+dconf2nixFile :: InputFilePath -> OutputFilePath -> Root -> Verbosity -> IO ()
+dconf2nixFile (InputFilePath input) (OutputFilePath output) root v =
   let run   = handler (T.writeFile output) (T.appendFile output) root
-      parse = parseFromFile (dconfParser es v) input
+      parse = parseFromFile (dconfParser v) input
   in  run =<< parse
 
-dconf2nixStdin :: Root -> EmojiSupport -> Verbosity -> IO ()
-dconf2nixStdin root es v =
+dconf2nixStdin :: Root -> Verbosity -> IO ()
+dconf2nixStdin root v =
   let run   = handler T.putStr T.putStr root
-      parse = runParser (dconfParser es v) () "<stdin>"
+      parse = runParser (dconfParser v) () "<stdin>"
   in  run . parse =<< T.getContents
 
 handler

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -72,7 +72,6 @@ renderValue raw = Nix $ renderValue' raw <> ";"
   renderValue' (B   v) = T.toLower . T.pack $ show v
   renderValue' (I   v) = T.pack $ show v
   renderValue' (D   v) = T.pack $ show v
-  renderValue' (Emo v) = "\"" <> T.singleton v <> "\""
   renderValue' (I32 v) = "mkUint32 " <> T.pack (show v)
   renderValue' (I64 v) = "mkInt64 " <> T.pack (show v)
   renderValue' (L  xs) = renderList xs

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -9,6 +9,7 @@ module Nix
   )
 where
 
+import           Data.Function                  ( (&) )
 import qualified Data.Map                      as Map
 import qualified Data.Text                     as T
 import           DConf.Data
@@ -68,7 +69,7 @@ renderValue raw = Nix $ renderValue' raw <> ";"
   renderList xs = let
     in "[ " <> T.intercalate " " (renderItem <$> xs) <> " ]"
 
-  renderValue' (S   v) = T.pack $ show v
+  renderValue' (S   v) = renderString v
   renderValue' (B   v) = T.toLower . T.pack $ show v
   renderValue' (I   v) = T.pack $ show v
   renderValue' (D   v) = T.pack $ show v
@@ -81,3 +82,13 @@ renderValue raw = Nix $ renderValue' raw <> ";"
     "''\n" <> mkSpaces 8 <> T.strip v <> "\n" <> mkSpaces 6 <> "''"
   renderValue' (R kvs) =
     "{\n" <> mconcat (fmap (\(k,v) -> mkSpaces 8 <> k <> " = " <> renderValue' v <> ";\n") kvs) <> mkSpaces 6 <> "}"
+
+renderString :: T.Text -> T.Text
+renderString text = "\"" <> escaped <> "\""
+  where
+    escaped =
+      text
+        & T.replace "\\" "\\\\"
+        & T.replace "\n" "\\n"
+        & T.replace "$" "\\$"
+        & T.replace "\"" "\\\""

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -140,6 +140,17 @@ prop_dconf2nix_tuples :: Property
 prop_dconf2nix_tuples =
   withTests (10 :: TestLimit) dconf2nixTuples
 
+dconf2nixUnicode :: Property
+dconf2nixUnicode =
+  let input  = "data/unicode.settings"
+      output = "output/unicode.nix"
+      root   = Root T.empty
+  in  baseProperty input output root
+
+prop_dconf2nix_unicode :: Property
+prop_dconf2nix_unicode =
+  withTests (10 :: TestLimit) dconf2nixUnicode
+
 dconf2nixEmoji :: Property
 dconf2nixEmoji =
   let input  = "data/emoji.settings"

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -17,11 +17,8 @@ import           Text.Parsec                    ( runParser )
 prop_dconf2nix :: Property
 prop_dconf2nix = withTests (10 :: TestLimit) dconf2nix
 
-baseProperty' :: FilePath -> FilePath -> Root -> Property
-baseProperty' i o root = baseProperty i o root Disabled
-
-baseProperty :: FilePath -> FilePath -> Root -> EmojiSupport -> Property
-baseProperty i o root es = property $ do
+baseProperty :: FilePath -> FilePath -> Root -> Property
+baseProperty i o root = property $ do
   input  <- evalIO $ T.readFile i
   output <- evalIO $ T.readFile o
   ref    <- evalIO $ newIORef T.empty
@@ -29,7 +26,7 @@ baseProperty i o root es = property $ do
   result <- evalIO $ readIORef ref
   result === output
  where
-  entries = runParser (dconfParser es Normal) () "<test>"
+  entries = runParser (dconfParser Normal) () "<test>"
   writer ref x = modifyIORef ref (`T.append` x)
 
 dconf2nix :: Property
@@ -37,7 +34,7 @@ dconf2nix =
   let input  = "data/dconf.settings"
       output = "output/dconf.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_custom_root :: Property
 prop_dconf2nix_custom_root = withTests (10 :: TestLimit) dconf2nixCustomRoot
@@ -47,7 +44,7 @@ dconf2nixCustomRoot =
   let input  = "data/custom.settings"
       output = "output/custom.nix"
       root   = Root "ca/desrt/dconf-editor"
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_custom_nested_root :: Property
 prop_dconf2nix_custom_nested_root =
@@ -58,14 +55,14 @@ dconf2nixCustomNestedRoot =
   let input  = "data/nested.settings"
       output = "output/nested.nix"
       root   = Root "org/gnome/desktop/peripherals"
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 dconf2nixIndexer :: Property
 dconf2nixIndexer =
   let input  = "data/indexer.settings"
       output = "output/indexer.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_indexer :: Property
 prop_dconf2nix_indexer = withTests (10 :: TestLimit) dconf2nixIndexer
@@ -75,7 +72,7 @@ dconf2nixNegative =
   let input  = "data/negative.settings"
       output = "output/negative.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_negative :: Property
 prop_dconf2nix_negative = withTests (10 :: TestLimit) dconf2nixNegative
@@ -85,7 +82,7 @@ dconf2nixJson =
   let input  = "data/json.settings"
       output = "output/json.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_json :: Property
 prop_dconf2nix_json = withTests (10 :: TestLimit) dconf2nixJson
@@ -95,7 +92,7 @@ dconf2nixClocks =
   let input  = "data/clocks.settings"
       output = "output/clocks.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_clocks :: Property
 prop_dconf2nix_clocks = withTests (10 :: TestLimit) dconf2nixClocks
@@ -105,7 +102,7 @@ dconf2nixKeybindings =
   let input  = "data/keybindings.settings"
       output = "output/keybindings.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_keybindings :: Property
 prop_dconf2nix_keybindings = withTests (10 :: TestLimit) dconf2nixKeybindings
@@ -115,7 +112,7 @@ dconf2nixScientificNotation =
   let input  = "data/scientific-notation.settings"
       output = "output/scientific-notation.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_scientific_notation :: Property
 prop_dconf2nix_scientific_notation =
@@ -126,7 +123,7 @@ dconf2nixHeaders =
   let input  = "data/headers.settings"
       output = "output/headers.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_headers :: Property
 prop_dconf2nix_headers =
@@ -137,7 +134,7 @@ dconf2nixTuples =
   let input  = "data/tuples.settings"
       output = "output/tuples.nix"
       root   = Root T.empty
-  in  baseProperty' input output root
+  in  baseProperty input output root
 
 prop_dconf2nix_tuples :: Property
 prop_dconf2nix_tuples =
@@ -148,7 +145,7 @@ dconf2nixEmoji =
   let input  = "data/emoji.settings"
       output = "output/emoji.nix"
       root   = Root T.empty
-  in  baseProperty input output root Enabled
+  in  baseProperty input output root
 
 prop_dconf2nix_emoji :: Property
 prop_dconf2nix_emoji =

--- a/test/DConfTest.hs
+++ b/test/DConfTest.hs
@@ -18,7 +18,7 @@ prop_simple_parser = withTests (100 :: TestLimit) simpleParser
 
 simpleParser :: Property
 simpleParser =
-  let entries = runParser (dconfParser Disabled Normal) () "<test>" testInput
+  let entries = runParser (dconfParser Normal) () "<test>" testInput
   in  property $ entries === Right [testOutput]
 
 testInput :: Text


### PR DESCRIPTION
`dconf dump` uses `g_variant_print`, which prints most Unicode characters verbatim. dconf2nix would read those and then use `show` to serialize the parsed strings. But `show` encodes Unicode characters as a decimal number preceded by a backslash, (e.g. `\129315`), which means nothing to Nix.

Let’s encode strings as UTF-8 when dumping them to Nix.

Also fix the test data from e2b5065718f4de55ce7afe4c8d385a123eaf3e1b, they were copied as reported by `parserTraced` but the actual data was mostly Unicode with few escape sequences.