### PR TITLE
Improve support for typed values

### DIFF
--- a/data/typed.settings
+++ b/data/typed.settings
@@ -1,0 +1,10 @@
+[typed]
+empty-dict=@a{sv} {}
+empty-array-dict=@a{sv} []
+just-str=@ms 'hello'
+ui32=uint32 7
+at-u=@u 5
+empty-arr=@a(dd) []
+just-empty-str=@ms ""
+doubletime=uint32 uint32 7
+var-empty-arr=<@ai []>

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -334,7 +334,7 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/shell/world-clocks" = {
-      locations = [];
+      locations = mkArray "v" [];
     };
 
     "org/gnome/software" = {

--- a/output/typed.nix
+++ b/output/typed.nix
@@ -1,0 +1,22 @@
+# Generated via dconf2nix: https://github.com/nix-commmunity/dconf2nix
+{ lib, ... }:
+
+with lib.hm.gvariant;
+
+{
+  dconf.settings = {
+    "typed" = {
+      at-u = mkTyped "u" 5;
+      doubletime = mkUint32 7;
+      empty-arr = mkArray "(dd)" [];
+      empty-array-dict = mkArray "{sv}" [];
+      empty-dict = mkTyped "a{sv}" {
+      };
+      just-empty-str = mkTyped "ms" "";
+      just-str = mkTyped "ms" "hello";
+      ui32 = mkUint32 7;
+      var-empty-arr = mkVariant (mkArray "i" []);
+    };
+
+  };
+}

--- a/output/variant.nix
+++ b/output/variant.nix
@@ -13,7 +13,7 @@ with lib.hm.gvariant;
       string = mkVariant "#polari";
       true = mkVariant true;
       tuple = mkVariant (mkTuple [ (mkUint32 2) "ABC" ]);
-      typed = mkVariant [];
+      typed = mkVariant (mkArray "i" []);
       uint32 = mkVariant (mkUint32 2);
       variant = mkVariant (mkVariant 7);
     };

--- a/src/DConf/Data.hs
+++ b/src/DConf/Data.hs
@@ -21,6 +21,7 @@ data Value = S Text         -- String
            | I64 Int        -- Int64
            | D Double       -- Double
            | T [Value]      -- Tuple of n-arity
+           | Ty String Value -- Typed value
            | L [Value]      -- List of values
            | V Value        -- Variant
            | R [(Text,Value)] -- Record

--- a/test/DConf2NixTest.hs
+++ b/test/DConf2NixTest.hs
@@ -140,6 +140,17 @@ prop_dconf2nix_tuples :: Property
 prop_dconf2nix_tuples =
   withTests (10 :: TestLimit) dconf2nixTuples
 
+dconf2nixTyped :: Property
+dconf2nixTyped =
+  let input  = "data/typed.settings"
+      output = "output/typed.nix"
+      root   = Root T.empty
+  in  baseProperty input output root
+
+prop_dconf2nix_typed :: Property
+prop_dconf2nix_typed =
+  withTests (10 :: TestLimit) dconf2nixTyped
+
 dconf2nixUnicode :: Property
 dconf2nixUnicode =
   let input  = "data/unicode.settings"


### PR DESCRIPTION
Using new `mkTyped` constructor, not yet supported by home-manager.
dict also continues to be broken for now.