### PR TITLE
Support almost arbitrary characters in dir names

### DIFF
--- a/data/dconf.settings
+++ b/data/dconf.settings
@@ -1,34 +1,8 @@
 [org/virt-manager/virt-manager/urls]
 isos=['/home/bbigras/Downloads/something {ddsa}']
 
-[ org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9 ]
+[org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9]
 foo=true
-
-[ org/gnome/desktop/interface ]
-clock-show-weekday=true
-document-font-name=' JetBrainsMono Nerd Font 11 '
-enable-hot-corners=false
-font-name=' JetBrainsMono Nerd Font 11 '
-gtk-im-module=' gtk-im-context-simple '
-gtk-theme=' Adwaita-dark '
-icon-theme=' Adwaita '
-monospace-font-name=' JetBrainsMono Nerd Font 10 '
-show-battery-percentage=true
-
-[ org/gnome/desktop/peripherals/mouse ]
-natural-scroll=false
-speed=-0.5
-
-[ org/gnome/desktop/peripherals/touchpad ]
-tap-to-click=false
-two-finger-scrolling-enabled=true
-
-[ org/gnome/desktop/screensaver ]
-picture-uri=' file:///home/gvolpe/Pictures/nixos.png '
-
-[ org/gnome/desktop/sound ]
-allow-volume-above-100-percent=true
-event-sounds=true
 
 [org/gnome/desktop/wm/keybindings]
 close=['<Super>w']
@@ -36,11 +10,6 @@ switch-applications=@as []
 switch-applications-backward=@as []
 switch-windows=['<Alt>Tab']
 switch-windows-backward=['<Shift><Alt>Tab']
-
-[ org/gnome/desktop/wm/preferences ]
-button-layout=' close,minimize,maximize:'
-titlebar-font='JetBrainsMono Nerd Font Mono 11'
-workspace-names=@as []
 
 [ca/desrt/dconf-editor]
 saved-pathbar-path='/org/gnome/desktop/input-sources/'
@@ -226,10 +195,6 @@ disabled-extensions=['apps-menu@gnome-shell-extensions.gcampax.github.com', 'pla
 enabled-extensions=['horizontal-workspaces@gnome-shell-extensions.gcampax.github.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com', 'screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com', 'workspace-indicator@gnome-shell-extensions.gcampax.github.com', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'dash-to-dock@micxgx.gmail.com', 'timepp@zagortenay333', 'TopIcons@phocean.net']
 favorite-apps=['chromium-browser.desktop', 'spotify.desktop', 'slack.desktop', 'telegramdesktop.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.tweaks.desktop', 'terminator.desktop']
 
-[org/gnome/shell/extensions/dash-to-dock ]
-dock-fixed=false
-dock-position=' BOTTOM '
-
 [org/gnome/shell/extensions/dash-to-dock]
 background-opacity=0.80000000000000004
 custom-theme-shrink=false
@@ -246,10 +211,6 @@ isolate-workspaces=true
 running-indicator-style='DEFAULT'
 show-trash=false
 transparency-mode='DEFAULT'
-
-[org/gnome/shell/extensions/desktop-icons ]
-show-home=false
-show-trash=false
 
 [org/gnome/shell/extensions/desktop-icons]
 show-home=false
@@ -329,3 +290,9 @@ pictures-directory=@ms nothing
 
 [org/gnome/easytag]
 default-path=b'/home/alice/Music'
+
+[ test / *#@= All the special characters ]
+foo_bar='test'
+
+[com/github/wwmm/easyeffects/streamoutputs/compressor#0]
+sidechain-input-device='alsa_input.platform-snd_aloop.0.analog-stereo'

--- a/data/emoji.settings
+++ b/data/emoji.settings
@@ -1,4 +1,4 @@
-[ org/gnome/Characters ]
+[org/gnome/Characters]
 recent-characters=['💡']
 some-other-character=['🤓']
 emoji-in-double-quotes=["🔥"]

--- a/output/dconf.nix
+++ b/output/dconf.nix
@@ -13,49 +13,12 @@ with lib.hm.gvariant;
       foo = true;
     };
 
-    "org/gnome/desktop/interface" = {
-      clock-show-weekday = true;
-      document-font-name = " JetBrainsMono Nerd Font 11 ";
-      enable-hot-corners = false;
-      font-name = " JetBrainsMono Nerd Font 11 ";
-      gtk-im-module = " gtk-im-context-simple ";
-      gtk-theme = " Adwaita-dark ";
-      icon-theme = " Adwaita ";
-      monospace-font-name = " JetBrainsMono Nerd Font 10 ";
-      show-battery-percentage = true;
-    };
-
-    "org/gnome/desktop/peripherals/mouse" = {
-      natural-scroll = false;
-      speed = -0.5;
-    };
-
-    "org/gnome/desktop/peripherals/touchpad" = {
-      tap-to-click = false;
-      two-finger-scrolling-enabled = true;
-    };
-
-    "org/gnome/desktop/screensaver" = {
-      picture-uri = " file:///home/gvolpe/Pictures/nixos.png ";
-    };
-
-    "org/gnome/desktop/sound" = {
-      allow-volume-above-100-percent = true;
-      event-sounds = true;
-    };
-
     "org/gnome/desktop/wm/keybindings" = {
       close = [ "<Super>w" ];
       switch-applications = [];
       switch-applications-backward = [];
       switch-windows = [ "<Alt>Tab" ];
       switch-windows-backward = [ "<Shift><Alt>Tab" ];
-    };
-
-    "org/gnome/desktop/wm/preferences" = {
-      button-layout = " close,minimize,maximize:";
-      titlebar-font = "JetBrainsMono Nerd Font Mono 11";
-      workspace-names = [];
     };
 
     "ca/desrt/dconf-editor" = {
@@ -285,11 +248,6 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/shell/extensions/dash-to-dock" = {
-      dock-fixed = false;
-      dock-position = " BOTTOM ";
-    };
-
-    "org/gnome/shell/extensions/dash-to-dock" = {
       background-opacity = 0.8;
       custom-theme-shrink = false;
       dash-max-icon-size = 48;
@@ -305,11 +263,6 @@ with lib.hm.gvariant;
       running-indicator-style = "DEFAULT";
       show-trash = false;
       transparency-mode = "DEFAULT";
-    };
-
-    "org/gnome/shell/extensions/desktop-icons" = {
-      show-home = false;
-      show-trash = false;
     };
 
     "org/gnome/shell/extensions/desktop-icons" = {
@@ -411,6 +364,14 @@ with lib.hm.gvariant;
 
     "org/gnome/easytag" = {
       default-path = mkByteString ''/home/alice/Music'';
+    };
+
+    " test / *#@= All the special characters " = {
+      foo_bar = "test";
+    };
+
+    "com/github/wwmm/easyeffects/streamoutputs/compressor#0" = {
+      sidechain-input-device = "alsa_input.platform-snd_aloop.0.analog-stereo";
     };
 
   };

--- a/src/DConf.hs
+++ b/src/DConf.hs
@@ -240,14 +240,12 @@ vDictDictEntry = bracket "{" "}" $ do
 
 dconfHeader :: Parsec Text () Header
 dconfHeader = bracket "[" "]" $ do
-  _ <- spaces
-  h <- many1 $ satisfy $ \c -> isAlphaNum c || elem c ("/.-:_" :: [Char])
-  _ <- spaces
+  h <- many1 $ satisfy $ \c -> not (isControl c) && not (elem c ("[]" :: [Char]))
   return $ T.pack h
 
 kvLine :: Parsec Text () (Key,Value)
 kvLine = do
-  k <- many1 $ satisfy $ \c -> isAlphaNum c || c == '-'
+  k <- many1 $ satisfy $ \c -> isAlphaNum c || c == '-' || c == '_'
   _ <- char '='
   v <- value
   _ <- endOfLine

--- a/test/DConfTest.hs
+++ b/test/DConfTest.hs
@@ -23,7 +23,7 @@ simpleParser =
 
 testInput :: Text
 testInput = T.unlines
-  [ "[ org/gnome/desktop/peripherals/mouse ]"
+  [ "[org/gnome/desktop/peripherals/mouse]"
   , "natural-scroll=false"
   , "speed=-0.5"
   ]


### PR DESCRIPTION
dconf itself places minimal restrictions on key paths. `dconf_is_key` and `dconf_is_dir` just stipulate the following:

- Path must start with `/`.
- Path must not contain `//`.
- Key paths must not end with `/`.
- Directory paths must end with `/`.

So in theory, they can all contain special characters like `[]*#@`. In practice, `dconf dump` will fail to print paths containing `[` or `]` due to limitations of `GKeyFile` enforced by `g_key_file_is_group_name` so those or control characters will not really appear in input of dconf2nix. But it can still contain all other kinds of characters including spaces at the start or end.

Since the spaces are now preserved as expected, we need to remove them from the test cases (not sure how they got there). Also clean up the duplicate dirs/groups.

Keys have slightly tighter restrictions introduced by `g_key_file_is_key_name`. Whitespace is only allowed in the middle of a key and `=` is not allowed at all. `[` and `]` are not allowed either, except at the end in a subkey suffix, which has further restrictions. But I doubt anyone will want special characters in keys so I am only extending it with an underscore.
