### PR TITLE
Refactor argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Type `--help` for some more information.
 ```shell
 dconf2nix - Nixify dconf configuration files
 
-Usage: dconf2nix [-v|--version] 
-                 [[-r|--root ARG] [--verbose] | (-i|--input ARG)
-                   (-o|--output ARG) [-r|--root ARG] [--verbose]]
+Usage: dconf2nix [-v|--version] [-r|--root ARG] [--verbose]
+                 [(-i|--input ARG) (-o|--output ARG)]
+
   Convert a dconf file into a Nix file, as expected by Home Manager.
 
 Available options:
@@ -117,8 +117,6 @@ Available options:
   --verbose                Verbose mode (debug)
   -i,--input ARG           Path to the dconf file (input)
   -o,--output ARG          Path to the Nix output file (to be created)
-  -r,--root ARG            Custom root path. e.g.: system/locale/
-  --verbose                Verbose mode (debug)
 ```
 
 #### Custom root

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,9 +2,9 @@
 
 module Main where
 
-import           CommandLine                    ( FileArgs(..)
+import           CommandLine                    ( Args(..)
+                                                , FileArgs(..)
                                                 , Input(..)
-                                                , StdinArgs(..)
                                                 , runArgs
                                                 )
 import           DConf2Nix                      ( dconf2nixFile
@@ -13,7 +13,7 @@ import           DConf2Nix                      ( dconf2nixFile
 
 main :: IO ()
 main = runArgs >>= \case
-  FileInput (FileArgs i o r v) ->
+  Args r v (FileInput (FileArgs i o)) ->
     dconf2nixFile i o r v
-  StdinInput (StdinArgs r v)   ->
+  Args r v StdinInput   ->
     dconf2nixStdin r v


### PR DESCRIPTION
Move input-independent arguments to a top-level product type rather than duplicating them in `FileArgs` and `StdinArgs`. Without this, specifying `--verbose` before `-i` would lock-in `StdinInput` alternative. The arguments would also be duplicated in the help page.
