### PR TITLE
Nix: Use mkDouble constructor for doubles

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -94,7 +94,7 @@ renderValue raw = Nix $ unparens (renderValue' raw) <> ";"
   renderValue' (B   v) = Atomic $ T.toLower . T.pack $ show v
   renderValue' (No   ) = error "Standalone nothing not supported"
   renderValue' (I   v) = (if v < 0 then NeedsParens else Atomic) (T.pack $ show v)
-  renderValue' (D   v) = (if v < 0 then NeedsParens else Atomic) (T.pack $ show v)
+  renderValue' (D   v) = NeedsParens $ "mkDouble \"" <> (T.pack $ show v) <> "\""
   renderValue' (C ty v) =
     NeedsParens $ case constrName ty of
       Just constr -> T.pack constr <> " " <> renderItem v

--- a/test/output/dump.nix
+++ b/test/output/dump.nix
@@ -114,7 +114,7 @@ with lib.hm.gvariant;
 
     "org/gnome/desktop/peripherals/mouse" = {
       natural-scroll = false;
-      speed = -0.5;
+      speed = mkDouble "-0.5";
     };
 
     "org/gnome/desktop/peripherals/touchpad" = {
@@ -166,7 +166,7 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/evince/default" = {
-      window-ratio = mkTuple [ 1.0081699346405228 0.7121212121212122 ];
+      window-ratio = mkTuple [ (mkDouble "1.0081699346405228") (mkDouble "0.7121212121212122") ];
     };
 
     "org/gnome/evolution-data-server" = {
@@ -221,7 +221,7 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/settings-daemon/plugins/color" = {
-      night-light-last-coordinates = mkTuple [ 43.68419928005759 (-79.3472) ];
+      night-light-last-coordinates = mkTuple [ (mkDouble "43.68419928005759") (mkDouble "-79.3472") ];
     };
 
     "org/gnome/settings-daemon/plugins/media-keys" = {
@@ -252,14 +252,14 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/shell/extensions/dash-to-dock" = {
-      background-opacity = 0.8;
+      background-opacity = mkDouble "0.8";
       custom-theme-shrink = false;
       dash-max-icon-size = 48;
       dock-fixed = false;
       dock-position = "BOTTOM";
       extend-height = false;
       force-straight-corner = false;
-      height-fraction = 0.9;
+      height-fraction = mkDouble "0.9";
       hot-keys = false;
       icon-size-fixed = false;
       intellihide-mode = "FOCUS_APPLICATION_WINDOWS";
@@ -318,12 +318,12 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/Weather" = {
-      locations = [ (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdańsk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ])) ])) ];
+      locations = [ (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdańsk" "EPGD" true [ (mkTuple [ (mkDouble "0.9491682190584854") (mkDouble "0.3223041410193837") ]) ] [ (mkTuple [ (mkDouble "0.9485864484589182") (mkDouble "0.32579479952337237") ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ (mkDouble "0.9302794944578734") (mkDouble "0.34699627038777753") ]) ] [ (mkTuple [ (mkDouble "0.938610530426954") (mkDouble "0.3574455077502486") ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ (mkDouble "0.9514923902475622") (mkDouble "0.3235888220312407") ]) ] [ (mkTuple [ (mkDouble "0.9485864484589182") (mkDouble "0.32579479952337237") ]) ] ])) ])) ];
     };
 
     "org/gnome/shell/weather" = {
       automatic-location = true;
-      locations = [ (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdańsk" "EPGD" true [ (mkTuple [ 0.9491682190584854 0.3223041410193837 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ 0.9302794944578734 0.34699627038777753 ]) ] [ (mkTuple [ 0.938610530426954 0.3574455077502486 ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ 0.9514923902475622 0.3235888220312407 ]) ] [ (mkTuple [ 0.9485864484589182 0.32579479952337237 ]) ] ])) ])) ];
+      locations = [ (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdańsk" "EPGD" true [ (mkTuple [ (mkDouble "0.9491682190584854") (mkDouble "0.3223041410193837") ]) ] [ (mkTuple [ (mkDouble "0.9485864484589182") (mkDouble "0.32579479952337237") ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Działdowo County, Warmian-Masurian Voivodeship" "" false [ (mkTuple [ (mkDouble "0.9302794944578734") (mkDouble "0.34699627038777753") ]) ] [ (mkTuple [ (mkDouble "0.938610530426954") (mkDouble "0.3574455077502486") ]) ] ])) ])) (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Gdynia, Pomeranian Voivodeship" "" false [ (mkTuple [ (mkDouble "0.9514923902475622") (mkDouble "0.3235888220312407") ]) ] [ (mkTuple [ (mkDouble "0.9485864484589182") (mkDouble "0.32579479952337237") ]) ] ])) ])) ];
     };
 
     "system/locale" = {
@@ -342,9 +342,9 @@ with lib.hm.gvariant;
 
     "issue28/org/gnome/clocks" = {
       world-clocks = [ [
-        (mkDictionaryEntry ["location" (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Houston" "KHOU" false [ (mkTuple [ 0.5172719570598194 (-1.6629933445314968) ]) ] [ (mkTuple [ 0.5172719570598194 (-1.6629933445314968) ]) ] ])) ]))])
+        (mkDictionaryEntry ["location" (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Houston" "KHOU" false [ (mkTuple [ (mkDouble "0.5172719570598194") (mkDouble "-1.6629933445314968") ]) ] [ (mkTuple [ (mkDouble "0.5172719570598194") (mkDouble "-1.6629933445314968") ]) ] ])) ]))])
       ] [
-        (mkDictionaryEntry ["location" (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Singapore" "WSAP" true [ (mkTuple [ 2.3852838928353343e-2 1.8136879868485383 ]) ] [ (mkTuple [ 2.2568084612667797e-2 1.8126262332513803 ]) ] ])) ]))])
+        (mkDictionaryEntry ["location" (mkVariant (mkTuple [ (mkUint32 2) (mkVariant (mkTuple [ "Singapore" "WSAP" true [ (mkTuple [ (mkDouble "2.3852838928353343e-2") (mkDouble "1.8136879868485383") ]) ] [ (mkTuple [ (mkDouble "2.2568084612667797e-2") (mkDouble "1.8126262332513803") ]) ] ])) ]))])
       ] ];
     };
 

--- a/test/output/nested.nix
+++ b/test/output/nested.nix
@@ -7,7 +7,7 @@ with lib.hm.gvariant;
   dconf.settings = {
     "org/gnome/desktop/peripherals/mouse" = {
       natural-scroll = false;
-      speed = -0.5;
+      speed = mkDouble "-0.5";
     };
 
     "org/gnome/desktop/peripherals/touchpad" = {

--- a/test/output/numbers.nix
+++ b/test/output/numbers.nix
@@ -6,17 +6,17 @@ with lib.hm.gvariant;
 {
   dconf.settings = {
     "floats" = {
-      avogadro = 6.283185307179586;
-      basic = 1.2345678901234567e9;
-      negative = -72.02;
-      positive = 72.02;
-      sci = 6.022e23;
-      sci-exp-neg = 7.51e-9;
-      sci-neg = -72020.0;
-      sci-neg-exp-neg = -9.11e-17;
-      zero = 0.0;
-      zero-neg = -0.0;
-      zero-pos = 0.0;
+      avogadro = mkDouble "6.283185307179586";
+      basic = mkDouble "1.2345678901234567e9";
+      negative = mkDouble "-72.02";
+      positive = mkDouble "72.02";
+      sci = mkDouble "6.022e23";
+      sci-exp-neg = mkDouble "7.51e-9";
+      sci-neg = mkDouble "-72020.0";
+      sci-neg-exp-neg = mkDouble "-9.11e-17";
+      zero = mkDouble "0.0";
+      zero-neg = mkDouble "-0.0";
+      zero-pos = mkDouble "0.0";
     };
 
     "int" = {

--- a/test/output/scientific-notation.nix
+++ b/test/output/scientific-notation.nix
@@ -6,8 +6,8 @@ with lib.hm.gvariant;
 {
   dconf.settings = {
     "com/github/wwmm/easyeffects/streamoutputs/bassenhancer" = {
-      amount = -6.938893903907228e-16;
-      blend = 0.0;
+      amount = mkDouble "-6.938893903907228e-16";
+      blend = mkDouble "0.0";
       listen = true;
     };
 

--- a/test/output/typed.nix
+++ b/test/output/typed.nix
@@ -9,7 +9,7 @@ with lib.hm.gvariant;
       at-u = mkTyped "u" 5;
       boolean = mkCast "boolean" true;
       byte = mkUchar 23;
-      double = mkCast "double" 28.2;
+      double = mkCast "double" (mkDouble "28.2");
       doubletime = mkUint32 (mkUint32 7);
       empty-arr = mkArray "(dd)" [];
       empty-array-dict = mkArray "{sv}" [];


### PR DESCRIPTION
Nix truncates floats, which makes the float literal unsuitable for keys that expect certain level of precision and reset the key otherwise, like `/org/gnome/shell/world-clocks/locations`.

https://www.github.com/NixOS/nix/issues/5733#issuecomment-1529002378
https://discourse.nixos.org/t/set-a-dconf-key-without-double-quotes/36142

    nix-repl> builtins.toJSON [ [(-0.65740735740229495) 2.5278185274873568] [(-0.6600253512802865) 2.5301456447922108] ]
    "[[-0.657407357402295,2.527818527487357],[-0.6600253512802865,2.530145644792211]]"

    nix-repl> builtins.toString (-0.65740735740229495)
    "-0.657407"

Fixes: https://github.com/nix-community/dconf2nix/issues/98
